### PR TITLE
Dedicated server edits

### DIFF
--- a/d2common/d2math/math.go
+++ b/d2common/d2math/math.go
@@ -167,3 +167,8 @@ func GetRadiansBetween(p1X, p1Y, p2X, p2Y float64) float64 {
 
 	return math.Atan2(deltaY, deltaX)
 }
+
+// ClampInt ensures that the given value is between or equal to the given min or max
+func ClampInt(value, min, max int) int {
+	return int(math.Min(math.Max(float64(value), float64(min)), float64(max)))
+}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/OpenDiablo2/OpenDiablo2/d2app"
@@ -21,6 +22,7 @@ func main() {
 	instance := d2app.Create(GitBranch, GitCommit)
 
 	if err := instance.Run(); err != nil {
+		fmt.Println(err)
 		return
 	}
 }


### PR DESCRIPTION
- Cleaned up argument parsing (kingpin stuff). 
- Moved the arguments stuff out of `dedicated_server.go` and into `app.go`.
- dedicated server no longer starts a renderer
- printing version now immediately exits